### PR TITLE
feature: add esm transpile step to prepublish

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,18 @@
+{
+  "env": {
+    "esm": {
+      "presets": [
+        [
+          "env",
+          {
+            "modules": false
+          }
+        ],
+        "react"
+      ],
+      "plugins": [
+        "transform-runtime"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+esm

--- a/package.json
+++ b/package.json
@@ -4,14 +4,25 @@
   "license": "MIT",
   "repository": "nodesource/react-window-resize",
   "description": "Resize the browser window",
+  "module": "esm/index.js",
   "scripts": {
-    "test": "prettier-standard '**/*.js' && standard"
+    "prepublishOnly": "npm run build:esm",
+    "test": "prettier-standard '**/*.js' && standard",
+    "build:esm": "BABEL_ENV=esm babel index.js --out-dir esm"
   },
-  "devDependencies": {
-    "prettier-standard": "^8.0.0",
-    "standard": "^11.0.0"
+  "peerDependencies": {
+    "react": "^16.2.0"
   },
   "dependencies": {
-    "react": "^16.2.0"
+    "babel-runtime": "^6.26.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
+    "prettier-standard": "^8.0.0",
+    "standard": "^11.0.0"
   }
 }


### PR DESCRIPTION
PR adds a prepublish build step that will output an entry that is appropriate for the `module` entry used by bundlers (webpack/rollup).

### Deps

* `react` is moved to a peer dep to signal it as required, but allow consumers to specify the version
* `babel-runtime` is a dependency according to Babel library authoring best practices: https://babeljs.io/docs/plugins/transform-runtime/

Details on the `module` target: https://github.com/rollup/rollup/wiki/pkg.module